### PR TITLE
fix: add version number to migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 script: "bundle exec rake"
 
 rvm:
-  - 1.9.3
   - 2.3.1
 
 env:

--- a/db/migrate/000_create_vcard_tables.rb
+++ b/db/migrate/000_create_vcard_tables.rb
@@ -1,4 +1,4 @@
-class CreateVcardTables < ActiveRecord::Migration
+class CreateVcardTables < ActiveRecord::Migration[4.2]
   def self.up
     create_table 'addresses', :force => true do |t|
       t.string  'post_office_box',  :limit => 50
@@ -47,4 +47,3 @@ class CreateVcardTables < ActiveRecord::Migration
     drop_table :vcards, :phone_numbers, :addresses
   end
 end
-

--- a/db/migrate/20120119091225_add_index_to_vcards.rb
+++ b/db/migrate/20120119091225_add_index_to_vcards.rb
@@ -1,4 +1,4 @@
-class AddIndexToVcards < ActiveRecord::Migration
+class AddIndexToVcards < ActiveRecord::Migration[4.2]
   def change
     add_index :vcards, :active
   end

--- a/db/migrate/20120813065226_add_time_stamps_to_has_vcards_tables.rb
+++ b/db/migrate/20120813065226_add_time_stamps_to_has_vcards_tables.rb
@@ -1,4 +1,4 @@
-class AddTimeStampsToHasVcardsTables < ActiveRecord::Migration
+class AddTimeStampsToHasVcardsTables < ActiveRecord::Migration[4.2]
   def self.up
     add_column :addresses, :created_at, :datetime
     add_column :addresses, :updated_at, :datetime

--- a/db/migrate/20121113120000_create_honorific_prefixes_table.rb
+++ b/db/migrate/20121113120000_create_honorific_prefixes_table.rb
@@ -1,4 +1,4 @@
-class CreateHonorificPrefixesTable < ActiveRecord::Migration
+class CreateHonorificPrefixesTable < ActiveRecord::Migration[4.2]
   def up
     create_table "honorific_prefixes" do |t|
       t.integer "sex"

--- a/db/migrate/20140617113710_rename_tables_for_namespacing.rb
+++ b/db/migrate/20140617113710_rename_tables_for_namespacing.rb
@@ -1,4 +1,4 @@
-class RenameTablesForNamespacing < ActiveRecord::Migration
+class RenameTablesForNamespacing < ActiveRecord::Migration[4.2]
   def change
     rename_table :addresses, :has_vcards_addresses
     rename_table :honorific_prefixes, :has_vcards_honorific_prefixes

--- a/db/migrate/20140619101337_remove_object_from_phone_number.rb
+++ b/db/migrate/20140619101337_remove_object_from_phone_number.rb
@@ -1,4 +1,4 @@
-class RemoveObjectFromPhoneNumber < ActiveRecord::Migration
+class RemoveObjectFromPhoneNumber < ActiveRecord::Migration[4.2]
   def change
     remove_column :has_vcards_phone_numbers, :object_id
     remove_column :has_vcards_phone_numbers, :object_type

--- a/db/migrate/20140619102041_rename_vcard_object_to_reference.rb
+++ b/db/migrate/20140619102041_rename_vcard_object_to_reference.rb
@@ -1,4 +1,4 @@
-class RenameVcardObjectToReference < ActiveRecord::Migration
+class RenameVcardObjectToReference < ActiveRecord::Migration[4.2]
   def change
     rename_column :has_vcards_vcards, :object_id,   :reference_id
     rename_column :has_vcards_vcards, :object_type, :reference_type

--- a/db/migrate/20140619121756_refactor_honorific_prefix.rb
+++ b/db/migrate/20140619121756_refactor_honorific_prefix.rb
@@ -1,4 +1,4 @@
-class RefactorHonorificPrefix < ActiveRecord::Migration
+class RefactorHonorificPrefix < ActiveRecord::Migration[4.2]
   def change
     drop_table :has_vcards_honorific_prefixes
   end

--- a/db/migrate/20141107181915_drop_lengh_limits.rb
+++ b/db/migrate/20141107181915_drop_lengh_limits.rb
@@ -1,4 +1,4 @@
-class DropLenghLimits < ActiveRecord::Migration
+class DropLenghLimits < ActiveRecord::Migration[4.2]
   def change
     change_column :has_vcards_addresses, :post_office_box, :string, limit: nil
     change_column :has_vcards_addresses, :extended_address, :string, limit: nil

--- a/has_vcards.gemspec
+++ b/has_vcards.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "simple_form"
   s.add_dependency "i18n_rails_helpers"
   s.add_dependency "haml"
-  s.add_dependency "mime-types", "< 3" # To stay compatible with Ruby 1.9
+  s.add_dependency "mime-types"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "pg"


### PR DESCRIPTION
Newer rails version need the migrations to be versionend. This fix adds the numbers to the migrations.